### PR TITLE
Various pre-hotfire changes

### DIFF
--- a/Dockerfile.logs
+++ b/Dockerfile.logs
@@ -27,4 +27,4 @@ ADD config.yaml /app/config.yaml
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-dev
 
-CMD ["uv", "run", "--no-dev", "see_logs", "-e", "-d", "-s"]
+CMD ["uv", "run", "--no-dev", "see_logs", "-e", "-d", "-s", "-p"]

--- a/PROTOCOL_WALKTHROUGH.md
+++ b/PROTOCOL_WALKTHROUGH.md
@@ -111,15 +111,20 @@ These packets have no payload. LENGTH = 9.
 
 ---
 
-### STATUS (10 bytes)
+### STATUS (11 + 2*N bytes, variable)
 
-Device status response. LENGTH = 10.
+Device status response and valve/control states. LENGTH = 11 + 2*N, where N is the number of valves/controls.
 
 ```
 Offset  Size  Type    Field   Description
 ------  ----  ------  ------  -------------------------
 0-8     9     -       header  Standard header
 9       1     uint8   status  DeviceStatus enum value
+10      1     uint8   count   Number of valves/controls (N)
+
+Repeated N times (2 bytes each):
++0      1     uint8   command_id  Index in device's control array
++1      1     uint8   command_state ControlState enum value
 ```
 
 ---

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -51,6 +51,9 @@ services:
       - MTX_RTSPADDRESS=:8558
       - MTX_API=yes
 
+    # Always restart media on dockerd start
+    restart: always
+
   redis:
     image: "redis:latest"
     ports:

--- a/libqretprop/API/fastAPI.py
+++ b/libqretprop/API/fastAPI.py
@@ -167,9 +167,15 @@ async def sendDeviceCommand(
             except ValueError:
                 raise HTTPException(400, f"STREAM frequency must be an integer, got '{cmd.args[0]}'")
         elif cmd.command == "CONTROL":
+            controlName = cmd.args[0]
+
             # CONTROL needs controlName and controlState
             if len(cmd.args) < 2:
                 raise HTTPException(400, "CONTROL requires control name and state")
+
+            if not isinstance(device, SensorMonitor) or controlName not in device.controls:
+                continue
+
             bgTasks.add_task(func, device, cmd.args[0], cmd.args[1])
         else:
             bgTasks.add_task(func, device, *cmd.args)

--- a/libqretprop/API/fastAPI.py
+++ b/libqretprop/API/fastAPI.py
@@ -155,6 +155,9 @@ async def sendDeviceCommand(
     if func is None:
         raise HTTPException(400, f"Unknown command {cmd.command!r}")
 
+    # Track if any commands were sent to at least one device, to avoid returning success if all targets were invalid
+    anyCommandsSent = False
+
     # Run the command in the background to not block the API
     for device in devices.values():
         if cmd.command == "STREAM":
@@ -163,22 +166,29 @@ async def sendDeviceCommand(
                 raise HTTPException(400, "STREAM requires a frequency argument")
             try:
                 freq = int(cmd.args[0])
+                anyCommandsSent = True
                 bgTasks.add_task(func, device, freq)
             except ValueError:
                 raise HTTPException(400, f"STREAM frequency must be an integer, got '{cmd.args[0]}'")
         elif cmd.command == "CONTROL":
-            controlName = cmd.args[0]
-
             # CONTROL needs controlName and controlState
             if len(cmd.args) < 2:
                 raise HTTPException(400, "CONTROL requires control name and state")
 
+            controlName = cmd.args[0].upper()
+            controlState = cmd.args[1].upper()
+
             if not isinstance(device, SensorMonitor) or controlName not in device.controls:
                 continue
 
-            bgTasks.add_task(func, device, cmd.args[0], cmd.args[1])
+            anyCommandsSent = True
+            bgTasks.add_task(func, device, controlName, controlState)
         else:
+            anyCommandsSent = True
             bgTasks.add_task(func, device, *cmd.args)
+
+    if not anyCommandsSent:
+        raise HTTPException(400, "No valid target devices for the command")
 
     return CommandResponse(
         status="sent",

--- a/libqretprop/API/fastAPI.py
+++ b/libqretprop/API/fastAPI.py
@@ -2,6 +2,7 @@ import json
 import time
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
+import asyncio
 import uvicorn
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Request, status
 from fastapi.middleware.cors import CORSMiddleware
@@ -112,13 +113,6 @@ class KasaDeviceInfo(BaseModel):
     host: str
     model: str
     active: bool
-
-class DeviceStatus(BaseModel):
-    name: str
-    controls: dict[str, str]
-
-class DeviceStatusResponse(BaseModel):
-    devices: list[DeviceStatus]
 
 # API Endpoints
 # ------------------------
@@ -343,33 +337,10 @@ async def getServerConfig() -> ConfigsResponse:
         configs[getattr(dev, "name", getattr(dev, "id", "unknown"))] = cfg
     return ConfigsResponse(count=len(configs), configs=configs)
 
-
-class StatusResponse(BaseModel):
-    status: dict[str, str]
-
-
 @app.get("/status", summary="Gets the current state of each valve. Status is reported to redis log channel.")
-async def getStatus() -> DeviceStatusResponse:
+async def getStatus() -> None:
     devices = deviceTools.getRegisteredDevices()
 
-    # Fill the status list with the current control states of each device
-    statusList = []
-
+    # Trigger a status request to all devices to get their latest states for the response and to log to the redis log channel
     for device in devices.values():
-        if isinstance(device, SensorMonitor):
-            controls = {}
-            for name, ctrl in device.controls.items():
-                controls[name] = ctrl.state
-
-                # Remap for consistency
-                if controls[name] == "CLOSE":
-                    controls[name] = "CLOSED"
-
-            deviceStatus = DeviceStatus(
-                name=device.name,
-                controls=controls,
-            )
-
-            statusList.append(deviceStatus)
-
-    return DeviceStatusResponse(devices=statusList)
+        await deviceTools.getStatus(device)

--- a/libqretprop/API/fastAPI.py
+++ b/libqretprop/API/fastAPI.py
@@ -94,6 +94,10 @@ class CommandResponse(BaseModel):
     message: str
 
 
+class AutoDiscoveryConfig(BaseModel):
+    enabled: bool
+    intervalSeconds: float
+
 class CameraInfo(BaseModel):
     ip: str
     hostname: str
@@ -196,7 +200,7 @@ async def sendDeviceCommand(
     )
 
 
-@app.get("/v1/cameras", summary="Get the list of connected cameras", dependencies=[Depends(authUser)])
+@app.get("/v1/cameras", summary="Get the list of connected cameras")
 async def getCameras() -> CameraList:
     cameras = cameraTools.cameraRegistry
 
@@ -209,23 +213,22 @@ async def getCameras() -> CameraList:
     return CameraList(cameras=cameraDataList)
 
 
-@app.post("/v1/cameras/reconnect", summary="Reconnect all cameras", dependencies=[Depends(authUser)])
-async def reconnectCameras(user: Annotated[str, Depends(authUser)]) -> CameraList:
-    ml.slog(f"User {user} sent camera reconnect")
+@app.post("/v1/cameras/reconnect", summary="Reconnect all cameras")
+async def reconnectCameras() -> CameraList:
+    ml.slog(f"User sent camera reconnect")
     await cameraTools.connectAllCameras()
     return await getCameras()
 
 
-@app.post("/v1/camera", summary="Control a camera's movement", dependencies=[Depends(authUser)])
+@app.post("/v1/camera", summary="Control a camera's movement")
 async def controlCamera(
     ip: str,
     x_movement: float,
     y_movement: float,
     bgTasks: BackgroundTasks,
-    user: Annotated[str, Depends(authUser)],
 ) -> CommandResponse:
 
-    ml.slog(f"User {user} sent camera move command to {ip}: <{x_movement}, {y_movement}>")
+    ml.slog(f"User sent camera move command to {ip}: <{x_movement}, {y_movement}>")
 
     bgTasks.add_task(
         cameraTools.moveCamera,
@@ -236,10 +239,10 @@ async def controlCamera(
 
     return CommandResponse(
         status="sent",
-        message=f"User {user} sent camera move command to {ip}: <{x_movement}, {y_movement}>",
+        message=f"User sent camera move command to {ip}: <{x_movement}, {y_movement}>",
     )
 
-@app.get("/v1/kasa", summary="Get the list of discovered Kasa devices", dependencies=[Depends(authUser)])
+@app.get("/v1/kasa", summary="Get the list of discovered Kasa devices")
 async def getKasaDevices() -> list[KasaDeviceInfo]:
     devices = list(kasaTools.kasaRegistry.values())
 
@@ -256,22 +259,20 @@ async def getKasaDevices() -> list[KasaDeviceInfo]:
         ml.elog(f"Failed to get Kasa device info: {e}")
         raise HTTPException(500, "Failed to get Kasa device info")
 
-@app.get("/v1/kasa/discover", summary="Discover Kasa devices on the network", dependencies=[Depends(authUser)])
-async def discoverKasaDevices(user: Annotated[str, Depends(authUser)]) -> list[KasaDeviceInfo]:
-    ml.slog(f"User {user} sent Kasa discover command")
+@app.get("/v1/kasa/discover", summary="Discover Kasa devices on the network")
+async def discoverKasaDevices() -> list[KasaDeviceInfo]:
+    ml.slog(f"User sent Kasa discover command")
     await kasaTools.discoverKasaDevices()
 
     return await getKasaDevices()
 
-@app.post("/v1/kasa", summary="Control a Kasa device's power state",
-            dependencies=[Depends(authUser)])
+@app.post("/v1/kasa", summary="Control a Kasa device's power state")
 async def controlKasaDevice(
     host: str,
     active: bool,
-    user: Annotated[str, Depends(authUser)],
 ) -> KasaDeviceInfo:
 
-    ml.slog(f"User {user} sent Kasa control command to {host}: active={active}")
+    ml.slog(f"User sent Kasa control command to {host}: active={active}")
 
     if host not in kasaTools.kasaRegistry:
         raise HTTPException(404, f"No Kasa device found at {host}")
@@ -285,6 +286,39 @@ async def controlKasaDevice(
     except Exception as e:
         ml.slog(f"Error while controlling Kasa device at {host} (active={active}): {repr(e)}")
         raise HTTPException(500, f"Failed to control Kasa device at {host}")
+
+
+@app.get("/v1/autodiscovery", summary="Get autodiscovery settings")
+async def getAutodiscoverySettings() -> AutoDiscoveryConfig:
+    return AutoDiscoveryConfig(
+        enabled=deviceTools.AUTODISCOVER_ENABLED,
+        intervalSeconds=deviceTools.AUTODISCOVER_INTERVAL,
+    )
+
+
+@app.post("/v1/autodiscovery", summary="Update autodiscovery settings")
+async def updateAutodiscoverySettings(
+    enabled: bool | None = None,
+    interval: float | None = None,
+) -> AutoDiscoveryConfig:
+    if interval is not None and interval <= 0:
+        raise HTTPException(400, "intervalSeconds must be greater than 0")
+
+    if enabled is not None:
+        deviceTools.AUTODISCOVER_ENABLED = enabled
+
+    if interval is not None:
+        deviceTools.AUTODISCOVER_INTERVAL = interval
+
+    ml.slog(
+        f"User updated autodiscovery: enabled={deviceTools.AUTODISCOVER_ENABLED}, "
+        f"interval={deviceTools.AUTODISCOVER_INTERVAL}s"
+    )
+
+    return AutoDiscoveryConfig(
+        enabled=deviceTools.AUTODISCOVER_ENABLED,
+        intervalSeconds=deviceTools.AUTODISCOVER_INTERVAL,
+    )
 
 
 class ConfigsResponse(BaseModel):

--- a/libqretprop/API/fastAPI.py
+++ b/libqretprop/API/fastAPI.py
@@ -353,6 +353,23 @@ async def getStatus() -> DeviceStatusResponse:
     devices = deviceTools.getRegisteredDevices()
 
     # Fill the status list with the current control states of each device
-    statusList = [DeviceStatus(name=device.name, controls=device.controlStates) for device in devices.values()]
+    statusList = []
+
+    for device in devices.values():
+        if isinstance(device, SensorMonitor):
+            controls = {}
+            for name, ctrl in device.controls.items():
+                controls[name] = ctrl.state
+
+                # Remap for consistency
+                if controls[name] == "CLOSE":
+                    controls[name] = "CLOSED"
+
+            deviceStatus = DeviceStatus(
+                name=device.name,
+                controls=controls,
+            )
+
+            statusList.append(deviceStatus)
 
     return DeviceStatusResponse(devices=statusList)

--- a/libqretprop/API/fastAPI.py
+++ b/libqretprop/API/fastAPI.py
@@ -292,7 +292,7 @@ async def controlKasaDevice(
 async def getAutodiscoverySettings() -> AutoDiscoveryConfig:
     return AutoDiscoveryConfig(
         enabled=deviceTools.AUTODISCOVER_ENABLED,
-        intervalSeconds=deviceTools.AUTODISCOVER_INTERVAL,
+        intervalSeconds=deviceTools.AUTODISCOVER_INTERVAL_S,
     )
 
 
@@ -308,16 +308,16 @@ async def updateAutodiscoverySettings(
         deviceTools.AUTODISCOVER_ENABLED = enabled
 
     if interval is not None:
-        deviceTools.AUTODISCOVER_INTERVAL = interval
+        deviceTools.AUTODISCOVER_INTERVAL_S = interval
 
     ml.slog(
         f"User updated autodiscovery: enabled={deviceTools.AUTODISCOVER_ENABLED}, "
-        f"interval={deviceTools.AUTODISCOVER_INTERVAL}s"
+        f"interval={deviceTools.AUTODISCOVER_INTERVAL_S}s"
     )
 
     return AutoDiscoveryConfig(
         enabled=deviceTools.AUTODISCOVER_ENABLED,
-        intervalSeconds=deviceTools.AUTODISCOVER_INTERVAL,
+        intervalSeconds=deviceTools.AUTODISCOVER_INTERVAL_S,
     )
 
 

--- a/libqretprop/API/fastAPI.py
+++ b/libqretprop/API/fastAPI.py
@@ -113,6 +113,13 @@ class KasaDeviceInfo(BaseModel):
     model: str
     active: bool
 
+class DeviceStatus(BaseModel):
+    name: str
+    controls: dict[str, str]
+
+class DeviceStatusResponse(BaseModel):
+    devices: list[DeviceStatus]
+
 # API Endpoints
 # ------------------------
 
@@ -342,6 +349,10 @@ class StatusResponse(BaseModel):
 
 
 @app.get("/status", summary="Gets the current state of each valve. Status is reported to redis log channel.")
-async def getStatus() -> None:
-    for device in deviceTools.deviceRegistry.values():
-        deviceTools.getStatus(device)
+async def getStatus() -> DeviceStatusResponse:
+    devices = deviceTools.getRegisteredDevices()
+
+    # Fill the status list with the current control states of each device
+    statusList = [DeviceStatus(name=device.name, controls=device.controlStates) for device in devices.values()]
+
+    return DeviceStatusResponse(devices=statusList)

--- a/libqretprop/API/fastAPI.py
+++ b/libqretprop/API/fastAPI.py
@@ -299,20 +299,20 @@ async def getAutodiscoverySettings() -> AutoDiscoveryConfig:
 @app.post("/v1/autodiscovery", summary="Update autodiscovery settings")
 async def updateAutodiscoverySettings(
     enabled: bool | None = None,
-    interval: float | None = None,
+    intervalSeconds: float | None = None,
 ) -> AutoDiscoveryConfig:
-    if interval is not None and interval <= 0:
+    if intervalSeconds is not None and intervalSeconds <= 0:
         raise HTTPException(400, "intervalSeconds must be greater than 0")
 
     if enabled is not None:
         deviceTools.AUTODISCOVER_ENABLED = enabled
 
-    if interval is not None:
-        deviceTools.AUTODISCOVER_INTERVAL_S = interval
+    if intervalSeconds is not None:
+        deviceTools.AUTODISCOVER_INTERVAL_S = intervalSeconds
 
     ml.slog(
         f"User updated autodiscovery: enabled={deviceTools.AUTODISCOVER_ENABLED}, "
-        f"interval={deviceTools.AUTODISCOVER_INTERVAL_S}s"
+        f"intervalSeconds={deviceTools.AUTODISCOVER_INTERVAL_S}s"
     )
 
     return AutoDiscoveryConfig(

--- a/libqretprop/DeviceControllers/deviceTools.py
+++ b/libqretprop/DeviceControllers/deviceTools.py
@@ -7,6 +7,7 @@ import time
 import libqretprop.mylogging as ml
 from libqretprop.Devices.ESPDevice import ESPDevice
 from libqretprop.Devices.SensorMonitor import SensorMonitor
+from libqretprop.protocol import ControlState
 
 
 MULTICAST_ADDRESS = "239.255.255.250"
@@ -157,6 +158,10 @@ async def tcpListener() -> None:
                         await loop.sock_sendall(client_socket, timesync.pack())
                         ml.plog(f"Sent initial TIMESYNC to {newDevice.name}")
 
+                        status_request = SimplePacket.create(PacketType.STATUS_REQUEST)
+                        await loop.sock_sendall(client_socket, status_request.pack())
+                        ml.plog(f"Sent initial STATUS_REQUEST to {newDevice.name}")
+
         except asyncio.CancelledError:
             ml.slog("TCP listener cancelled")
             server_socket.close()
@@ -248,7 +253,16 @@ async def _monitorSingleDevice(device: ESPDevice) -> None:
                                 ml.log(f"{device.name} {t:.3f} {sensor_name}:{reading.value:.2f}")
 
                     elif packet.header.packet_type == PacketType.STATUS:
-                        ml.plog(f"{device.name} status: {packet.status.name}")
+                        # If SensorMonitor, log control states
+                        if isinstance(device, SensorMonitor) and packet.control_states:
+                            # Read control states from payload (if any) and update internal state
+                            for control_state in packet.control_states:
+                                control_names = list(device.controls.keys())
+                                if control_state.id < len(control_names):
+                                    control_name = control_names[control_state.id]
+                                    state_str = "OPEN" if control_state.state == ControlState.OPEN else "CLOSED" if control_state.state == ControlState.CLOSED else "UNKNOWN"
+                                    device.controls[control_name].state = state_str
+                                    ml.log(f"{device.name} STATUS {control_name} {state_str}")
 
                     elif packet.header.packet_type == PacketType.ACK:
                         if packet.ack_packet_type == PacketType.TIMESYNC:
@@ -264,12 +278,9 @@ async def _monitorSingleDevice(device: ESPDevice) -> None:
                                 control_name, state = device._pending_controls.pop(packet.ack_sequence)
                                 ml.plog(f"{device.name} CONTROL {control_name} {state}")
 
-                                # Update internal control state on ACK
-                                # Changed CLOSE -> CLOSED for consistency with config
-                                if state == "CLOSE":
-                                    state = "CLOSED"
+                                if isinstance(device, SensorMonitor) and control_name in device.controls:
 
-                                device.controlStates[control_name] = state
+                                    device.controls[control_name].state = state
                             else:
                                 ml.plog(f"{device.name} ACK for CONTROL seq={packet.ack_sequence}")
                         else:
@@ -408,11 +419,26 @@ async def setControl(device: SensorMonitor, controlName: str, controlState: str)
             if packet.header.sequence in device._pending_controls:
                 device._pending_controls.pop(packet.header.sequence)
             if device.address in deviceRegistry:
-                _removed = deviceRegistry.pop(device.address)
-                ml.slog(f"{device.name} removed from registry.")
+                removeDevice(device)
     else:
         ml.elog(f"No socket available for {device.name} to send CONTROL command.")
 
+async def getStatus(device: ESPDevice) -> None:
+    from libqretprop.protocol import PacketType, SimplePacket
+
+    if device.socket:
+        try:
+            packet = SimplePacket.create(PacketType.STATUS_REQUEST)
+            loop = asyncio.get_event_loop()
+            await loop.sock_sendall(device.socket, packet.pack())
+            ml.slog(f"Sent STATUS_REQUEST command to {device.name}")
+        except Exception as e:
+            ml.elog(f"Error sending STATUS_REQUEST command to {device.name}: {e}")
+            if device.address in deviceRegistry:
+                removeDevice(device)
+    else:
+        ml.elog(f"No socket available for {device.name} to send STATUS_REQUEST command.")
+        removeDevice(device)
 
 def removeDevice(device: ESPDevice) -> None:
     if device.address in deviceRegistry:

--- a/libqretprop/DeviceControllers/deviceTools.py
+++ b/libqretprop/DeviceControllers/deviceTools.py
@@ -145,6 +145,7 @@ async def tcpListener() -> None:
                         deviceRegistry[deviceIP].listenerTask = listenerTask
 
                         ml.slog(f"Device {newDevice.name} registered from {deviceIP}")
+                        ml.log(f"{newDevice.name} CONNECTED") # Used by GUI to trigger device addition
 
                         # ACK the CONFIG, then send initial TIMESYNC
                         from libqretprop.protocol import AckPacket, SimplePacket
@@ -296,8 +297,13 @@ async def _monitorSingleDevice(device: ESPDevice) -> None:
                     ml.elog(f"Error decoding packet from {device.name}: {e}")
                     buffer = buffer[1:]
 
+    except asyncio.CancelledError:
+        ml.slog(f"Stopped monitoring {device.name}")
+        raise
     except Exception as e:
         ml.elog(f"Error receiving response from {device.name}: {e}")
+        if device.address in deviceRegistry:
+            removeDevice(device)
 
 
 # ---------------------- #
@@ -430,6 +436,7 @@ def removeDevice(device: ESPDevice) -> None:
                 ml.elog(f"Error cancelling listener task for {device.name}: {e}")
         deviceRegistry.pop(device.address)
         ml.slog(f"{device.name} removed from registry.")
+        ml.log(f"{device.name} DISCONNECTED") # Used by GUI to trigger device removal
 
 
 # ---------------------- #

--- a/libqretprop/DeviceControllers/deviceTools.py
+++ b/libqretprop/DeviceControllers/deviceTools.py
@@ -15,7 +15,7 @@ MULTICAST_PORT = 1900
 TCP_PORT = 50000
 
 AUTODISCOVER_ENABLED = True
-AUTODISCOVER_INTERVAL = 30.0 # seconds between SSDP discovery broadcasts
+AUTODISCOVER_INTERVAL_S = 30.0 # seconds between SSDP discovery broadcasts
 
 # Searching Globals #
 ssdpSearchSocket: socket.socket | None = None
@@ -54,7 +54,7 @@ async def autoDiscoveryLoop() -> None:
     while True:
         if AUTODISCOVER_ENABLED:
             sendDiscoveryBroadcast()
-            await asyncio.sleep(AUTODISCOVER_INTERVAL)
+            await asyncio.sleep(AUTODISCOVER_INTERVAL_S)
         else:
             await asyncio.sleep(0.5)
 
@@ -211,6 +211,7 @@ async def _monitorSingleDevice(device: ESPDevice) -> None:
             data = await loop.sock_recv(device.socket, 4096)
             if not data:
                 ml.elog(f"Device {device.name} disconnected.")
+                removeDevice(device)
                 break
 
             buffer += data
@@ -253,11 +254,14 @@ async def _monitorSingleDevice(device: ESPDevice) -> None:
                             device.last_sync_time = time.monotonic()
                             device._resync_pending = False
                             ml.plog(f"{device.name} TIMESYNC completed")
+                        elif packet.ack_packet_type == PacketType.HEARTBEAT:
+                            device.handleHeartbeatAck(packet.ack_sequence)
+                            ml.plog(f"{device.name} HEARTBEAT ACK seq={packet.ack_sequence}")
                         elif packet.ack_packet_type == PacketType.CONTROL:
                             # Check for pending control command
                             if packet.ack_sequence in device._pending_controls:
                                 control_name, state = device._pending_controls.pop(packet.ack_sequence)
-                                ml.log(f"{device.name} CONTROL {control_name} {state}")
+                                ml.plog(f"{device.name} CONTROL {control_name} {state}")
                             else:
                                 ml.plog(f"{device.name} ACK for CONTROL seq={packet.ack_sequence}")
                         else:
@@ -413,7 +417,14 @@ async def getStatus(device: ESPDevice) -> None:
 
 def removeDevice(device: ESPDevice) -> None:
     if device.address in deviceRegistry:
-        _removed = deviceRegistry.pop(device.address)
+        if device.socket:
+            try:
+                device.socket.close()
+                ml.slog(f"Closed socket for {device.name}")
+            except OSError as e:
+                ml.elog(f"Error closing socket for {device.name}: {e}")
+
+        deviceRegistry.pop(device.address)
         ml.slog(f"{device.name} removed from registry.")
 
 

--- a/libqretprop/DeviceControllers/deviceTools.py
+++ b/libqretprop/DeviceControllers/deviceTools.py
@@ -276,11 +276,12 @@ async def _monitorSingleDevice(device: ESPDevice) -> None:
                             # Check for pending control command
                             if packet.ack_sequence in device._pending_controls:
                                 control_name, state = device._pending_controls.pop(packet.ack_sequence)
-                                ml.plog(f"{device.name} CONTROL {control_name} {state}")
 
+                                # Send status log for control ACK
+                                state_str = "OPEN" if state == "OPEN" else "CLOSED" if state == "CLOSE" else "UNKNOWN"
                                 if isinstance(device, SensorMonitor) and control_name in device.controls:
-
                                     device.controls[control_name].state = state
+                                    ml.log(f"{device.name} STATUS {control_name} {state_str}")
                             else:
                                 ml.plog(f"{device.name} ACK for CONTROL seq={packet.ack_sequence}")
                         else:

--- a/libqretprop/DeviceControllers/deviceTools.py
+++ b/libqretprop/DeviceControllers/deviceTools.py
@@ -14,6 +14,9 @@ MULTICAST_PORT = 1900
 
 TCP_PORT = 50000
 
+AUTODISCOVER_ENABLED = True
+AUTODISCOVER_INTERVAL = 30.0 # seconds between SSDP discovery broadcasts
+
 # Searching Globals #
 ssdpSearchSocket: socket.socket | None = None
 
@@ -46,6 +49,14 @@ def sendDiscoveryBroadcast() -> None:
 
     ssdpSearchSocket.sendto(ssdpRequest.encode(), (MULTICAST_ADDRESS, MULTICAST_PORT))
 
+async def autoDiscoveryLoop() -> None:
+    """Periodically send SSDP discovery broadcasts every AUTODISCOVER_INTERVAL seconds."""
+    while True:
+        if AUTODISCOVER_ENABLED:
+            sendDiscoveryBroadcast()
+            await asyncio.sleep(AUTODISCOVER_INTERVAL)
+        else:
+            await asyncio.sleep(0.5)
 
 def _createSSDPSocket() -> socket.socket:
     """Create a send-only SSDP socket for broadcasting discovery."""
@@ -143,7 +154,7 @@ async def tcpListener() -> None:
 
                         timesync = SimplePacket.create(PacketType.TIMESYNC)
                         await loop.sock_sendall(client_socket, timesync.pack())
-                        ml.slog(f"Sent initial TIMESYNC to {newDevice.name}")
+                        ml.plog(f"Sent initial TIMESYNC to {newDevice.name}")
 
         except asyncio.CancelledError:
             ml.slog("TCP listener cancelled")
@@ -215,7 +226,7 @@ async def _monitorSingleDevice(device: ESPDevice) -> None:
                     packet_data = buffer[: header.length]
                     packet = decode_packet(packet_data)
 
-                    ml.slog(f"Decoded {packet.header.packet_type.name} from {device.name}")
+                    ml.plog(f"Decoded {packet.header.packet_type.name} from {device.name}")
 
                     if packet.header.packet_type == PacketType.DATA and isinstance(device, SensorMonitor):
                         # Device timestamps are already in server monotonic ms (locked via TIMESYNC)
@@ -235,25 +246,25 @@ async def _monitorSingleDevice(device: ESPDevice) -> None:
                                 ml.log(f"{device.name} {t:.3f} {sensor_name}:{reading.value:.2f}")
 
                     elif packet.header.packet_type == PacketType.STATUS:
-                        ml.slog(f"{device.name} status: {packet.status.name}")
+                        ml.plog(f"{device.name} status: {packet.status.name}")
 
                     elif packet.header.packet_type == PacketType.ACK:
                         if packet.ack_packet_type == PacketType.TIMESYNC:
                             device.last_sync_time = time.monotonic()
                             device._resync_pending = False
-                            ml.slog(f"{device.name} TIMESYNC completed")
+                            ml.plog(f"{device.name} TIMESYNC completed")
                         elif packet.ack_packet_type == PacketType.CONTROL:
                             # Check for pending control command
                             if packet.ack_sequence in device._pending_controls:
                                 control_name, state = device._pending_controls.pop(packet.ack_sequence)
                                 ml.log(f"{device.name} CONTROL {control_name} {state}")
                             else:
-                                ml.slog(f"{device.name} ACK for CONTROL seq={packet.ack_sequence}")
+                                ml.plog(f"{device.name} ACK for CONTROL seq={packet.ack_sequence}")
                         else:
-                            ml.slog(f"{device.name} ACK for {packet.ack_packet_type.name} seq={packet.ack_sequence}")
+                            ml.plog(f"{device.name} ACK for {packet.ack_packet_type.name} seq={packet.ack_sequence}")
 
                     elif packet.header.packet_type == PacketType.NACK:
-                        ml.elog(f"{device.name} NACK for {packet.nack_packet_type.name} error={packet.error_code.name}")
+                        ml.plog(f"{device.name} NACK for {packet.nack_packet_type.name} error={packet.error_code.name}")
 
                     buffer = buffer[header.length :]
 
@@ -266,7 +277,7 @@ async def _monitorSingleDevice(device: ESPDevice) -> None:
                         device._resync_pending = True
                         timesync = SimplePacket.create(PacketType.TIMESYNC)
                         await loop.sock_sendall(device.socket, timesync.pack())
-                        ml.slog(f"{device.name} resync sent (stale >{ESPDevice.RESYNC_INTERVAL_S / 60:.0f} min)")
+                        ml.plog(f"{device.name} resync sent (stale >{ESPDevice.RESYNC_INTERVAL_S / 60:.0f} min)")
 
                 except ValueError:
                     break

--- a/libqretprop/DeviceControllers/deviceTools.py
+++ b/libqretprop/DeviceControllers/deviceTools.py
@@ -262,6 +262,13 @@ async def _monitorSingleDevice(device: ESPDevice) -> None:
                             if packet.ack_sequence in device._pending_controls:
                                 control_name, state = device._pending_controls.pop(packet.ack_sequence)
                                 ml.plog(f"{device.name} CONTROL {control_name} {state}")
+
+                                # Update internal control state on ACK
+                                # Changed CLOSE -> CLOSED for consistency with config
+                                if state == "CLOSE":
+                                    state = "CLOSED"
+
+                                device.controlStates[control_name] = state
                             else:
                                 ml.plog(f"{device.name} ACK for CONTROL seq={packet.ack_sequence}")
                         else:
@@ -400,20 +407,6 @@ async def setControl(device: SensorMonitor, controlName: str, controlState: str)
     else:
         ml.elog(f"No socket available for {device.name} to send CONTROL command.")
 
-
-async def getStatus(device: ESPDevice) -> None:
-    from libqretprop.protocol import PacketType, SimplePacket
-
-    if device.socket:
-        try:
-            packet = SimplePacket.create(PacketType.STATUS_REQUEST)
-            loop = asyncio.get_event_loop()
-            await loop.sock_sendall(device.socket, packet.pack())
-            ml.slog(f"Sent STATUS_REQUEST to {device.name}")
-        except Exception as e:
-            ml.elog(f"Error sending STATUS_REQUEST to {device.name}: {e}")
-    else:
-        ml.elog(f"No socket available for {device.name} to send STATUS_REQUEST.")
 
 def removeDevice(device: ESPDevice) -> None:
     if device.address in deviceRegistry:

--- a/libqretprop/DeviceControllers/deviceTools.py
+++ b/libqretprop/DeviceControllers/deviceTools.py
@@ -423,7 +423,18 @@ def removeDevice(device: ESPDevice) -> None:
                 ml.slog(f"Closed socket for {device.name}")
             except OSError as e:
                 ml.elog(f"Error closing socket for {device.name}: {e}")
+            finally:
+                # Ensure other code can detect that the device is no longer connected
+                device.socket = None
 
+        # Cancel any per-device listener task to avoid it running against a closed socket
+        listener_task = getattr(device, "listenerTask", None)
+        if listener_task is not None:
+            try:
+                listener_task.cancel()
+                ml.slog(f"Cancelled listener task for {device.name}")
+            except Exception as e:
+                ml.elog(f"Error cancelling listener task for {device.name}: {e}")
         deviceRegistry.pop(device.address)
         ml.slog(f"{device.name} removed from registry.")
 

--- a/libqretprop/DeviceControllers/deviceTools.py
+++ b/libqretprop/DeviceControllers/deviceTools.py
@@ -232,10 +232,10 @@ async def _monitorSingleDevice(device: ESPDevice) -> None:
                     if packet.header.packet_type == PacketType.DATA and isinstance(device, SensorMonitor):
                         # Device timestamps are already in server monotonic ms (locked via TIMESYNC)
                         if device.last_sync_time is not None:
-                            t = packet.header.timestamp / 1000.0 - device.startTime
+                            t = packet.header.timestamp / 1000.0
                         else:
                             ml.slog(f"WARNING: {device.name} data before TIMESYNC, using server time")
-                            t = time.monotonic() - device.startTime
+                            t = time.monotonic()
 
                         sensor_names = list(device.sensors.keys())
                         for reading in packet.readings:

--- a/libqretprop/Devices/ESPDevice.py
+++ b/libqretprop/Devices/ESPDevice.py
@@ -40,13 +40,6 @@ class ESPDevice:
         self.name: str = jsonConfig["deviceName"]
         self.type = jsonConfig["deviceType"]
 
-        # Track the current control states of the device
-        self.controlStates = {}
-
-        # Set default states from config
-        for controlName in jsonConfig.get("controls", []):
-            self.controlStates[controlName] = jsonConfig["controls"][controlName].get("defaultState", "UNKNOWN")
-
         # Timesync state: track when last sync completed for periodic resync
         self.last_sync_time: float | None = None  # server monotonic time of last sync
         self._resync_pending: bool = False

--- a/libqretprop/Devices/ESPDevice.py
+++ b/libqretprop/Devices/ESPDevice.py
@@ -40,6 +40,13 @@ class ESPDevice:
         self.name: str = jsonConfig["deviceName"]
         self.type = jsonConfig["deviceType"]
 
+        # Track the current control states of the device
+        self.controlStates = {}
+
+        # Set default states from config
+        for controlName in jsonConfig.get("controls", []):
+            self.controlStates[controlName] = jsonConfig["controls"][controlName].get("defaultState", "UNKNOWN")
+
         # Timesync state: track when last sync completed for periodic resync
         self.last_sync_time: float | None = None  # server monotonic time of last sync
         self._resync_pending: bool = False

--- a/libqretprop/Devices/ESPDevice.py
+++ b/libqretprop/Devices/ESPDevice.py
@@ -2,6 +2,9 @@ import asyncio
 import socket
 from typing import TYPE_CHECKING, Any, ClassVar
 
+import libqretprop.mylogging as ml
+from libqretprop.DeviceControllers import deviceTools
+from libqretprop.protocol import PacketType, SimplePacket
 
 if TYPE_CHECKING:
     from libqretprop.Devices.SensorMonitor import SensorMonitor
@@ -20,6 +23,8 @@ class ESPDevice:
     """
 
     RESYNC_INTERVAL_S: ClassVar[float] = 600.0  # 10 minutes
+    HEARTBEAT_INTERVAL_S: ClassVar[float] = 5.0
+    HEARTBEAT_ACK_MISS_LIMIT: ClassVar[int] = 3
 
     def __init__(
         self,
@@ -42,17 +47,42 @@ class ESPDevice:
         # Pending control commands awaiting ACK (sequence -> (control_name, state))
         self._pending_controls: dict[int, tuple[str, str]] = {}
 
+        self.is_responsive: bool = True
+        self._heartbeat_ack_pending: bool = False
+        self._last_heartbeat_sequence: int | None = None
+        self._missed_heartbeat_acks: int = 0
+
         asyncio.create_task(self.heartbeat())
+
+    def handleHeartbeatAck(self, ack_sequence: int) -> None:
+        if self._heartbeat_ack_pending and ack_sequence != self._last_heartbeat_sequence:
+            ml.plog(
+                f"{self.name} HEARTBEAT ACK sequence mismatch: expected {self._last_heartbeat_sequence}, got {ack_sequence}"
+            )
+
+        self._heartbeat_ack_pending = False
+        self._missed_heartbeat_acks = 0
+        self.is_responsive = True
 
     async def heartbeat(self) -> None:
         """Send a heartbeat to the device every 5 seconds to keep TCP alive."""
         while True:
             if self.socket:
                 import contextlib
-                from libqretprop.protocol import SimplePacket, PacketType
 
-                with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+                if self._heartbeat_ack_pending:
+                    self._missed_heartbeat_acks += 1
+                    if self._missed_heartbeat_acks >= self.HEARTBEAT_ACK_MISS_LIMIT:
+                        self.is_responsive = False
+                        ml.elog(f"{self.name} marked unresponsive: missed {self._missed_heartbeat_acks} HEARTBEAT ACKs")
+                        deviceTools.removeDevice(self)
+                        break
+
+                with contextlib.suppress(BrokenPipeError, ConnectionResetError, OSError):
                     packet = SimplePacket.create(PacketType.HEARTBEAT)
                     loop = asyncio.get_event_loop()
                     await loop.sock_sendall(self.socket, packet.pack())
-            await asyncio.sleep(5)
+                    self._last_heartbeat_sequence = packet.header.sequence
+                    self._heartbeat_ack_pending = True
+
+            await asyncio.sleep(self.HEARTBEAT_INTERVAL_S)

--- a/libqretprop/Devices/ESPDevice.py
+++ b/libqretprop/Devices/ESPDevice.py
@@ -75,8 +75,6 @@ class ESPDevice:
         """Send a heartbeat to the device every 5 seconds to keep TCP alive."""
         while True:
             if self.socket:
-                import contextlib
-
                 if self._heartbeat_ack_pending:
                     self._missed_heartbeat_acks += 1
                     if self._missed_heartbeat_acks >= self.HEARTBEAT_ACK_MISS_LIMIT:
@@ -85,11 +83,15 @@ class ESPDevice:
                         deviceTools.removeDevice(self)
                         break
 
-                with contextlib.suppress(BrokenPipeError, ConnectionResetError, OSError):
+                try:
                     packet = SimplePacket.create(PacketType.HEARTBEAT)
                     loop = asyncio.get_event_loop()
                     await loop.sock_sendall(self.socket, packet.pack())
                     self._last_heartbeat_sequence = packet.header.sequence
                     self._heartbeat_ack_pending = True
+                except (BrokenPipeError, ConnectionResetError, OSError) as e:
+                    ml.elog(f"{self.name} heartbeat send failed: {e}")
+                    deviceTools.removeDevice(self)
+                    break
 
             await asyncio.sleep(self.HEARTBEAT_INTERVAL_S)

--- a/libqretprop/GuiDataStream.py
+++ b/libqretprop/GuiDataStream.py
@@ -64,7 +64,7 @@ async def websocket_logs(websocket: WebSocket):
     try:
         r = await get_redis_client()
         pubsub = r.pubsub()
-        await pubsub.subscribe("log", "errlog", "debuglog", "syslog")
+        await pubsub.subscribe("log", "errlog", "debuglog", "syslog", "packetlog")
         ml.dlog("WebSocket: Subscribed to Redis log channels")
 
         listener_task = asyncio.create_task(redis_listener(pubsub, websocket))
@@ -78,7 +78,7 @@ async def websocket_logs(websocket: WebSocket):
             ml.elog(f"WebSocket: error occurred - {e}")
         finally:
             listener_task.cancel()
-            await pubsub.unsubscribe("log", "errlog", "debuglog", "syslog")
+            await pubsub.unsubscribe("log", "errlog", "debuglog", "syslog", "packetlog")
             await pubsub.close()
             await r.close()
             ml.dlog("WebSocket: connection closed")

--- a/libqretprop/daemons/cliTerminal.py
+++ b/libqretprop/daemons/cliTerminal.py
@@ -31,7 +31,8 @@ DEVICECOMMANDS = [
     "CONTROL",
     "OPEN",
     "CLOSE",
-    ]
+    "STATUS",
+]
 
 
 async def handleServerCommand(command: str, args: list) -> None:
@@ -146,6 +147,7 @@ async def handleServerCommand(command: str, args: list) -> None:
         ml.slog("  stop <device>      - Stop streaming")
         ml.slog("  open <dev> <ctrl>  - Open valve/control")
         ml.slog("  close <dev> <ctrl> - Close valve/control")
+        ml.slog("  status <device>    - Get device status / control states")
         ml.slog("  expo               - Export data to CSV")
         ml.slog("  quit               - Exit")
     elif cmd == "EXPO":
@@ -206,6 +208,9 @@ async def handleDeviceCommand(command: str, args: list) -> None:
                 return
             await deviceTools.setControl(device, args[1], "CLOSE")
             ml.slog(f"Closed {args[1]} on {device.name}")
+        elif cmd == "STATUS":
+            await deviceTools.getStatus(device)
+            ml.slog(f"Requested status from {device.name}")
     except Exception as e:
         ml.elog(f"Error: {e}")
 

--- a/libqretprop/daemons/cliTerminal.py
+++ b/libqretprop/daemons/cliTerminal.py
@@ -12,6 +12,8 @@ SERVERCOMMANDS = [
     "QUIT",
     "EXIT",
     "DISCOVER",
+    "AUTODISCOVERY",
+    "AUTOD",
     "LIST",
     "EXPO",
     "HELP",
@@ -42,6 +44,45 @@ async def handleServerCommand(command: str, args: list) -> None:
         ml.slog("Sending discovery broadcast...")
         deviceTools.sendDiscoveryBroadcast()
         ml.slog("Discovery sent. Devices will auto-connect.")
+    elif cmd in ("AUTODISCOVERY", "AUTOD"):
+        if not args:
+            ml.slog(
+                f"Autodiscovery: enabled={deviceTools.AUTODISCOVER_ENABLED}, "
+                f"interval={deviceTools.AUTODISCOVER_INTERVAL}s",
+            )
+            ml.slog("Usage: autodiscovery <on|off|interval <seconds>|status>")
+            return
+
+        sub = args[0].lower()
+        if sub in ("status", "show"):
+            ml.slog(
+                f"Autodiscovery: enabled={deviceTools.AUTODISCOVER_ENABLED}, "
+                f"interval={deviceTools.AUTODISCOVER_INTERVAL}s",
+            )
+        elif sub in ("on", "enable", "enabled", "true"):
+            deviceTools.AUTODISCOVER_ENABLED = True
+            ml.slog("Autodiscovery enabled")
+        elif sub in ("off", "disable", "disabled", "false"):
+            deviceTools.AUTODISCOVER_ENABLED = False
+            ml.slog("Autodiscovery disabled")
+        elif sub == "interval":
+            if len(args) < 2:
+                ml.slog("Usage: autodiscovery interval <seconds>")
+                return
+            try:
+                interval = float(args[1])
+            except ValueError:
+                ml.slog(f"Invalid interval: {args[1]!r}. Must be a positive number.")
+                return
+
+            if interval <= 0:
+                ml.slog("Autodiscovery interval must be greater than 0 seconds")
+                return
+
+            deviceTools.AUTODISCOVER_INTERVAL = interval
+            ml.slog(f"Autodiscovery interval set to {interval}s")
+        else:
+            ml.slog("Usage: autodiscovery <on|off|interval <seconds>|status>")
     elif cmd == "LIST":
         devices = deviceTools.getRegisteredDevices()
         if not devices:
@@ -95,6 +136,10 @@ async def handleServerCommand(command: str, args: list) -> None:
     elif cmd == "HELP":
         ml.slog("Available commands:")
         ml.slog("  discover           - Discover devices")
+        ml.slog("  autodiscovery      - Show autodiscovery status")
+        ml.slog("  autodiscovery on   - Enable periodic discovery")
+        ml.slog("  autodiscovery off  - Disable periodic discovery")
+        ml.slog("  autodiscovery interval <seconds> - Set discovery interval")
         ml.slog("  list               - Show connected devices")
         ml.slog("  info <device>      - Show device details")
         ml.slog("  stream <dev> <hz>  - Start streaming")

--- a/libqretprop/daemons/cliTerminal.py
+++ b/libqretprop/daemons/cliTerminal.py
@@ -48,7 +48,7 @@ async def handleServerCommand(command: str, args: list) -> None:
         if not args:
             ml.slog(
                 f"Autodiscovery: enabled={deviceTools.AUTODISCOVER_ENABLED}, "
-                f"interval={deviceTools.AUTODISCOVER_INTERVAL}s",
+                f"interval={deviceTools.AUTODISCOVER_INTERVAL_S}s",
             )
             ml.slog("Usage: autodiscovery <on|off|interval <seconds>|status>")
             return
@@ -57,7 +57,7 @@ async def handleServerCommand(command: str, args: list) -> None:
         if sub in ("status", "show"):
             ml.slog(
                 f"Autodiscovery: enabled={deviceTools.AUTODISCOVER_ENABLED}, "
-                f"interval={deviceTools.AUTODISCOVER_INTERVAL}s",
+                f"interval={deviceTools.AUTODISCOVER_INTERVAL_S}s",
             )
         elif sub in ("on", "enable", "enabled", "true"):
             deviceTools.AUTODISCOVER_ENABLED = True
@@ -79,7 +79,7 @@ async def handleServerCommand(command: str, args: list) -> None:
                 ml.slog("Autodiscovery interval must be greater than 0 seconds")
                 return
 
-            deviceTools.AUTODISCOVER_INTERVAL = interval
+            deviceTools.AUTODISCOVER_INTERVAL_S = interval
             ml.slog(f"Autodiscovery interval set to {interval}s")
         else:
             ml.slog("Usage: autodiscovery <on|off|interval <seconds>|status>")

--- a/libqretprop/mylogging.py
+++ b/libqretprop/mylogging.py
@@ -55,3 +55,7 @@ def elog(message: str) -> None:
 def dlog(message: str) -> None:
     """Log a debug message to the redis debug log channel."""
     _publishLog("debuglog", message, color="yellow")
+
+def plog(message: str) -> None:
+    """Log a packet info message to the redis packet log channel."""
+    _publishLog("packetlog", message, color="grey")

--- a/libqretprop/protocol.py
+++ b/libqretprop/protocol.py
@@ -191,27 +191,40 @@ DiscoveryPacket = SimplePacket
 
 
 @dataclass
+class ControlStatus:
+    id: int
+    state: ControlState
+
+@dataclass
 class StatusPacket:
-    """Device status. Header + 1 byte status. Total: 10 bytes."""
-    PAYLOAD_FORMAT: ClassVar[str] = ">B"
+    """Device status + Batched control states. Header + 1 byte status + 1 byte length + [command_id (1B) + command_state (1B)] * N. Total: 11 + 2*N bytes."""
+    PAYLOAD_FORMAT: ClassVar[str] = ">BB" # status (1B) + control count (1B)
+    READING_FORMAT: ClassVar[str] = ">BB" # command_id (1B) + command_state (1B)
 
     header: PacketHeader
     status: DeviceStatus
+    control_states: list[ControlStatus] = field(default_factory=list)
 
     def pack(self) -> bytes:
-        return self.header.pack() + struct.pack(self.PAYLOAD_FORMAT, self.status)
+        return self.header.pack() + struct.pack(self.PAYLOAD_FORMAT, self.status, len(self.control_states)) + b''.join(
+            struct.pack(self.READING_FORMAT, cs.id, cs.state) for cs in self.control_states
+        )
 
     @classmethod
-    def create(cls, status: DeviceStatus) -> "StatusPacket":
-        header = _make_header(PacketType.STATUS, PacketHeader.SIZE + 1)
-        return cls(header=header, status=status)
+    def create(cls, status: DeviceStatus, control_states: list[ControlStatus] | None = None) -> "StatusPacket":
+        header = _make_header(PacketType.STATUS, PacketHeader.SIZE + 2 + (len(control_states) * 2 if control_states else 0))
+        return cls(header=header, status=status, control_states=control_states or [])
 
     @classmethod
     def unpack(cls, data: bytes) -> "StatusPacket":
         header = PacketHeader.unpack(data)
         s = PacketHeader.SIZE
-        status, = struct.unpack(cls.PAYLOAD_FORMAT, data[s:s + 1])
-        return cls(header=header, status=DeviceStatus(status))
+        status, control_count = struct.unpack(cls.PAYLOAD_FORMAT, data[s:s + 2])
+        control_states = []
+        for i in range(control_count):
+            cmd_id, cmd_state = struct.unpack(cls.READING_FORMAT, data[s + 2 + i * 2:s + 2 + (i + 1) * 2])
+            control_states.append(ControlStatus(id=cmd_id, state=ControlState(cmd_state)))
+        return cls(header=header, status=DeviceStatus(status), control_states=control_states)
 
 
 @dataclass

--- a/libqretprop/server.py
+++ b/libqretprop/server.py
@@ -61,8 +61,9 @@ async def main(noDiscovery: bool = False,
         daemons["tcpListener"] = loop.create_task(deviceTools.tcpListener())
         ml.slog("Started TCP listener daemon task.")
 
-        # Send a discovery broadcast
-        deviceTools.sendDiscoveryBroadcast()
+        # Start SSDP auto-discovery loop for finding devices on the network
+        daemons["autoDiscovery"] = loop.create_task(deviceTools.autoDiscoveryLoop())
+        ml.slog("Started SSDP auto-discovery daemon task.")
 
     # Connect to all cameras
     daemons["cameraConnector"] = loop.create_task(cameraTools.connectAllCameras())

--- a/qretproptools/cli/mock_device/mock_device.py
+++ b/qretproptools/cli/mock_device/mock_device.py
@@ -108,6 +108,8 @@ class MockSensorDevice:
         self.streaming = False
         self.stream_frequency = 10
         self.stream_task = None
+        self.command_task = None
+        self.ssdp_task = None
 
         # Timesync offset: added to local ticks to produce server-scale timestamps
         self.timesync_offset = 0
@@ -115,6 +117,45 @@ class MockSensorDevice:
         # Socket
         self.sock = None
         self.ssdp_sock = None
+
+    def reset_device_state(self, announce: bool = False):
+        """Reset runtime state after a disconnect."""
+        self.streaming = False
+        if self.stream_task:
+            self.stream_task.cancel()
+            self.stream_task = None
+
+        self.tc1_temp = 23.0
+        self.tc2_temp = 25.0
+        self.pt1_pressure = 14.7
+
+        self.valve_states = {
+            "AVFILL": "CLOSED",
+            "AVVENT": "CLOSED"
+        }
+
+        self.timesync_offset = 0
+
+        if announce:
+            self.print_status("Device state reset after disconnect", "INFO")
+
+    def ensure_ssdp_listener(self):
+        """Start SSDP listener in background if not already running."""
+        if self.ssdp_task and not self.ssdp_task.done():
+            return
+        self.ssdp_task = asyncio.create_task(self.start_ssdp_listener())
+
+    async def handle_server_disconnect(self):
+        """Clean up socket and resume discovery mode after a server disconnect."""
+        if self.sock:
+            with contextlib.suppress(Exception):
+                self.sock.close()
+        self.sock = None
+
+        self.server_ip = None
+        self.reset_device_state(announce=True)
+        self.print_status("Listening for discovery after disconnect...", "WARNING")
+        self.ensure_ssdp_listener()
 
     def _pack_with_adjusted_ts(self, packet) -> bytes:
         """Pack a packet, replacing the header timestamp with an offset-adjusted one.
@@ -144,6 +185,11 @@ class MockSensorDevice:
     async def start_ssdp_listener(self):
         """Listen for SSDP discovery broadcasts and extract server IP."""
         self.print_status("Starting SSDP listener on 239.255.255.250:1900")
+
+        if self.ssdp_sock:
+            with contextlib.suppress(Exception):
+                self.ssdp_sock.close()
+            self.ssdp_sock = None
 
         self.ssdp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         self.ssdp_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -200,7 +246,7 @@ class MockSensorDevice:
 
             await self.send_config()
 
-            asyncio.create_task(self.handle_commands())
+            self.command_task = asyncio.create_task(self.handle_commands())
 
         except Exception as e:
             self.print_status(f"Connection failed: {e}", "ERROR")
@@ -227,7 +273,7 @@ class MockSensorDevice:
             while True:
                 data = await loop.sock_recv(self.sock, 4096)
                 if not data:
-                    self.print_status("Server disconnected", "ERROR")
+                    self.print_status("Server disconnected", "WARNING")
                     break
 
                 buffer += data
@@ -287,6 +333,10 @@ class MockSensorDevice:
 
         except Exception as e:
             self.print_status(f"Command handler error: {e}", "ERROR")
+        finally:
+            self.command_task = None
+            if self.sock is not None:
+                await self.handle_server_disconnect()
 
     async def handle_control_command(self, packet: ControlPacket):
         command_id = packet.command_id
@@ -408,13 +458,20 @@ class MockSensorDevice:
                 pass
         else:
             self.print_status("Waiting for server discovery...", "INFO")
+            self.ensure_ssdp_listener()
             try:
-                await self.start_ssdp_listener()
+                await asyncio.Event().wait()
             except KeyboardInterrupt:
                 pass
 
         if self.sock:
             self.sock.close()
+        if self.command_task:
+            self.command_task.cancel()
+        if self.stream_task:
+            self.stream_task.cancel()
+        if self.ssdp_task:
+            self.ssdp_task.cancel()
         if self.ssdp_sock:
             self.ssdp_sock.close()
 

--- a/qretproptools/cli/mock_device/mock_device.py
+++ b/qretproptools/cli/mock_device/mock_device.py
@@ -26,6 +26,7 @@ from libqretprop.protocol import (
     ConfigPacket,
     ControlPacket,
     ControlState,
+    ControlStatus,
     DataPacket,
     DeviceStatus,
     ErrorCode,
@@ -80,12 +81,12 @@ class MockSensorDevice:
                 },
             },
             "controls": {
-                "AV1": {
+                "AVDUMP": {
                     "pin": 10,
                     "type": "valve",
                     "defaultState": "CLOSED",
                 },
-                "AV2": {
+                "AVFILL": {
                     "pin": 11,
                     "type": "valve",
                     "defaultState": "OPEN",
@@ -105,8 +106,9 @@ class MockSensorDevice:
 
         # Control states
         self.valve_states = {
-            "AVFILL": "CLOSED",
-            "AVVENT": "CLOSED"
+            "AVDUMP": "CLOSED",
+            "AVFILL": "OPEN",
+            "AV3": "OPEN",
         }
 
         # Streaming state
@@ -135,8 +137,9 @@ class MockSensorDevice:
         self.pt1_pressure = 14.7
 
         self.valve_states = {
-            "AVFILL": "CLOSED",
-            "AVVENT": "CLOSED"
+            "AVDUMP": "CLOSED",
+            "AVFILL": "OPEN",
+            "AV3": "OPEN",
         }
 
         self.timesync_offset = 0
@@ -445,12 +448,20 @@ class MockSensorDevice:
         await loop.sock_sendall(self.sock, self._pack_with_adjusted_ts(ack))
 
     async def send_status(self):
-        status = StatusPacket.create(DeviceStatus.ACTIVE)
+        control_states = []
+        # Preserve the order of controls as defined in the config
+        for control_name in self.config["controls"]:
+            state_str = self.valve_states.get(control_name, "UNKNOWN")
+            state_enum = ControlState.OPEN if state_str == "OPEN" else ControlState.CLOSED if state_str == "CLOSED" else ControlState.ERROR
+            control_states.append(ControlStatus(id=len(control_states), state=state_enum))
+
+        status = StatusPacket.create(DeviceStatus.ACTIVE, control_states=control_states)
 
         loop = asyncio.get_event_loop()
         await loop.sock_sendall(self.sock, self._pack_with_adjusted_ts(status))
 
         self.print_status("Sent STATUS: ACTIVE", "INFO")
+        self.print_status(f"Control states: " + ", ".join(f"{name}={self.valve_states.get(name, 'UNKNOWN')}" for name in self.config["controls"]), "INFO")
 
     async def run(self):
         self.print_status("=== Mock Sensor Device Started ===", "SUCCESS")

--- a/qretproptools/cli/mock_device/mock_device.py
+++ b/qretproptools/cli/mock_device/mock_device.py
@@ -336,11 +336,17 @@ class MockSensorDevice:
                         self.print_status(f"Error decoding packet: {e}", "ERROR")
                         break
 
+        except asyncio.CancelledError:
+            # Task was cancelled, likely due to shutdown; avoid treating as an error.
+            self.print_status("Command handler cancelled", "INFO")
+            raise
         except Exception as e:
             self.print_status(f"Command handler error: {e}", "ERROR")
         finally:
             self.command_task = None
-            if self.sock is not None:
+            # Avoid triggering disconnect handling when this task is being cancelled
+            task = asyncio.current_task()
+            if self.sock is not None and not (task and task.cancelled()):
                 await self.handle_server_disconnect()
 
     async def handle_control_command(self, packet: ControlPacket):

--- a/qretproptools/cli/see_logs/see_logs.py
+++ b/qretproptools/cli/see_logs/see_logs.py
@@ -13,6 +13,7 @@ def main() -> None:
     parser.add_argument("-e", "--elog", action="store_true", help="Show error logs")
     parser.add_argument("-d", "--debug", action="store_true", help="Show debug logs")
     parser.add_argument("-s", "--slog", action="store_true", help="Show standard logs")
+    parser.add_argument("-p", "--plog", action="store_true", help="Show packet logs")
     args = parser.parse_args()
 
     channels = []
@@ -20,6 +21,7 @@ def main() -> None:
     if args.elog:   channels.append("errlog")
     if args.debug:  channels.append("debuglog")
     if args.slog:   channels.append("syslog")
+    if args.plog:   channels.append("packetlog")
 
     print(f"Listening to channels: {', '.join(channels)}")
 

--- a/qretproptools/cli/start_server/start_server.py
+++ b/qretproptools/cli/start_server/start_server.py
@@ -21,7 +21,7 @@ def main() -> None:
     """Start the QRET server."""
     args = parseArgs()
     asyncio.run(server.main(
-        noDiscovery=args.no_discovery
+        noDiscovery=args.no_discovery,
     ))
 
 if __name__ == "__main__":

--- a/test_protocol.py
+++ b/test_protocol.py
@@ -13,6 +13,7 @@ from libqretprop.protocol import (
     ConfigPacket,
     ControlPacket,
     ControlState,
+    ControlStatus,
     DataPacket,
     decode_packet,
     DeviceStatus,
@@ -223,13 +224,22 @@ def test_status_packet() -> bool:
     passed = True
 
     for status in [DeviceStatus.INACTIVE, DeviceStatus.ACTIVE, DeviceStatus.ERROR, DeviceStatus.CALIBRATING]:
-        packet = StatusPacket.create(status=status)
-        packed = packet.pack()
-        unpacked = StatusPacket.unpack(packed)
+        # Test with both no control states and with some control states
+        for control_states in (None, [ControlStatus(id=1, state=ControlState.OPEN), ControlStatus(id=2, state=ControlState.CLOSED)]):
+            packet = StatusPacket.create(status=status, control_states=control_states)
+            packed = packet.pack()
+            unpacked = StatusPacket.unpack(packed)
 
-        passed &= assert_equal(len(packed), 10, f"Status {status.name}: size is 10 bytes")
-        passed &= assert_equal(unpacked.header.packet_type, PacketType.STATUS, f"Status {status.name}: type correct")
-        passed &= assert_equal(unpacked.status, status, f"Status {status.name}: status preserved")
+            num_controls = len(control_states) if control_states else 0
+
+            passed &= assert_equal(len(packed), 11 + num_controls * 2, f"Status {status.name} [{num_controls}]: size is 15 bytes")
+            passed &= assert_equal(unpacked.header.packet_type, PacketType.STATUS, f"Status {status.name}: type correct")
+            passed &= assert_equal(unpacked.status, status, f"Status {status.name} [{num_controls}]: status preserved")
+            passed &= assert_equal(len(unpacked.control_states), num_controls, f"Status {status.name} [{num_controls}]: control count preserved")
+            if control_states:
+                for i, (orig, decoded) in enumerate(zip(control_states, unpacked.control_states)):
+                    passed &= assert_equal(decoded.id, orig.id, f"Status {status.name} Control {i}: ID preserved")
+                    passed &= assert_equal(decoded.state, orig.state, f"Status {status.name} Control {i}: state preserved")
 
     return passed
 


### PR DESCRIPTION
* Mock device is now reset to default state on disconnection from server, will auto reconnect to server on next discovery request
* Packet-related logs moved from syslog to new packet log channel to avoid flooding
* ESPDevices are automatically removed/unregistered after missing 3 heartbeat acks (measured by the time the next heartbeat ack is sent)
* Server automatically sends discovery requests every 30 seconds, can be enabled/disabled and interval changed via cli terminal or web api
* Media docker compose service now set to `restart: always` in prod to be consistent with other services
* Fix timestamp to no longer be relative to individual device start time
* Add CONNECT and DISCONNECT logs for GUI to use
* Status packet now includes valve/control states, logs on status update for GUI, `/status` endpoint force requests status updates from devices