### PR TITLE
Mediamtx-based camera recording

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ build/
 data/
 configs/
 .claude/
+recordings/
 
 *.egg-info

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -17,6 +17,7 @@ services:
 
     volumes:
       - ./config.yaml:/app/config.yaml # Mount local config file for development
+      - ./recordings/mediamtx:/app/recordings/mediamtx
 
     develop:
       watch:
@@ -40,7 +41,7 @@ services:
       dockerfile: Dockerfile.logs
     depends_on:
       - redis
-      
+
     # Required for consistency of shared config of redis ip
     # Normal containers cannot access localhost, host networked containers cannot use docker internal DNS
     network_mode: "host"
@@ -71,6 +72,8 @@ services:
       - MTX_API=yes
       # Windows firewall blocks UDP, so use TCP for development streams
       - MTX_WEBRTCLOCALTCPADDRESS=:8189
+    volumes:
+      - ./recordings/mediamtx:/recordings
 
   redis:
     image: "redis:latest"

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -15,6 +15,7 @@ services:
 
     volumes:
       - ./config.yaml:/app/config.yaml  # Mount local config file for production
+      - ./recordings/mediamtx:/app/recordings/mediamtx
 
     # Always restart server on dockerd start
     restart: always
@@ -53,6 +54,8 @@ services:
 
     # Always restart media on dockerd start
     restart: always
+    volumes:
+      - ./recordings/mediamtx:/recordings
 
   redis:
     image: "redis:latest"

--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,7 @@ services:
     ip: localhost
     api_port: 9997
     webrtc_port: 8889 # Relayed to GUI for connection
+    recordings_dir: ./recordings/mediamtx
 
 cameras:
   - ip: 192.168.1.5

--- a/libqretprop/API/fastAPI.py
+++ b/libqretprop/API/fastAPI.py
@@ -115,6 +115,7 @@ class CameraInfo(BaseModel):
     ip: str
     hostname: str
     stream_path: str
+    recording: bool
 
 
 class CameraList(BaseModel):
@@ -234,7 +235,7 @@ async def getCameras() -> CameraList:
     cameraDataList = []
 
     for cam in cameras.values():
-        cameraData = CameraInfo(ip=cam.address, hostname=cam.hostname, stream_path=f"/{cam.address}")
+        cameraData = CameraInfo(ip=cam.address, hostname=cam.hostname, stream_path=f"/{cam.address}", recording=cam.recording)
         cameraDataList.append(cameraData)
 
     return CameraList(cameras=cameraDataList)

--- a/libqretprop/API/fastAPI.py
+++ b/libqretprop/API/fastAPI.py
@@ -1,14 +1,16 @@
 import json
 import time
 from typing import TYPE_CHECKING, Annotated, Any, Literal
+from urllib.parse import quote
 
-import asyncio
 import uvicorn
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import BaseModel
-from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+from starlette.responses import FileResponse
 
 from libqretprop import mylogging as ml
 from libqretprop.DeviceControllers import cameraTools, deviceTools, kasaTools
@@ -28,12 +30,22 @@ security = HTTPBasic()
 class AccessLogMiddleware(BaseHTTPMiddleware):
     """Middleware to log requests to ml.slog instead of stdout."""
 
-    async def dispatch(self, request: Request, call_next):
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         start_time = time.perf_counter()
         response = await call_next(request)
         duration_ms = (time.perf_counter() - start_time) * 1000
+
+        client = request.client
+        if client is None:
+            clientHost = "unknown"
+            clientPort = "unknown"
+        else:
+            clientHost = client.host
+            clientPort = str(client.port)
+
         ml.slog(
-            f'{request.client.host}:{request.client.port} - "{request.method} {request.url.path} HTTP/1.1" {response.status_code} ({duration_ms:.0f}ms)'
+            f'{clientHost}:{clientPort} - "{request.method} {request.url.path} HTTP/1.1" '
+            f"{response.status_code} ({duration_ms:.0f}ms)",
         )
         return response
 
@@ -108,11 +120,25 @@ class CameraInfo(BaseModel):
 class CameraList(BaseModel):
     cameras: list[CameraInfo]
 
+
+class CameraRecordingFileInfo(BaseModel):
+    filename: str
+    camera_ip: str | None
+    camera_hostname: str | None
+    size_bytes: int
+    modified_unix_ms: int
+    download_path: str
+
+
+class CameraRecordingList(BaseModel):
+    recordings: list[CameraRecordingFileInfo]
+
 class KasaDeviceInfo(BaseModel):
     alias: str
     host: str
     model: str
     active: bool
+
 
 # API Endpoints
 # ------------------------
@@ -242,6 +268,78 @@ async def controlCamera(
         status="sent",
         message=f"User sent camera move command to {ip}: <{x_movement}, {y_movement}>",
     )
+
+@app.post("/v1/camera/recordings/start", summary="Start recording a camera's stream")
+async def startCameraRecording(
+    ip: str,
+) -> CommandResponse:
+
+    ml.slog(f"User sent camera recording start command to {ip}")
+
+    try:
+        await cameraTools.startCameraRecording(ip)
+    except Exception as e:
+        raise HTTPException(500, f"Failed to start recording for camera at {ip}") from e
+
+    return CommandResponse(
+        status="sent",
+        message=f"User sent camera recording start command to {ip}",
+    )
+
+@app.post("/v1/camera/recordings/stop", summary="Stop recording a camera's stream")
+async def stopCameraRecording(
+    ip: str,
+) -> CommandResponse:
+
+    ml.slog(f"User sent camera recording stop command to {ip}")
+
+    try:
+        await cameraTools.stopCameraRecording(ip)
+    except Exception as e:
+        raise HTTPException(500, f"Failed to stop recording for camera at {ip}") from e
+
+    return CommandResponse(
+        status="sent",
+        message=f"User sent camera recording stop command to {ip}",
+    )
+
+
+@app.get("/v1/camera/recordings", summary="List camera recordings available for download")
+async def listCameraRecordings(ip: str | None = None) -> CameraRecordingList:
+    try:
+        cameraRecordingFiles = cameraTools.listRecordingFiles(ip)
+    except Exception as e:
+        ml.elog(f"Failed to list camera recordings: {e}")
+        raise HTTPException(500, "Failed to list camera recordings") from e
+
+    cameraRecordings = [
+        CameraRecordingFileInfo(
+            filename=cameraRecording["filename"],
+            camera_ip=cameraRecording["camera_ip"],
+            camera_hostname=cameraRecording["camera_hostname"],
+            size_bytes=cameraRecording["size_bytes"],
+            modified_unix_ms=cameraRecording["modified_unix_ms"],
+            download_path=f"/v1/camera/recordings/download/{quote(cameraRecording['filename'])}",
+        )
+        for cameraRecording in cameraRecordingFiles
+    ]
+
+    return CameraRecordingList(recordings=cameraRecordings)
+
+
+@app.get("/v1/camera/recordings/download/{filename}", summary="Download a camera recording file")
+async def downloadCameraRecording(filename: str) -> FileResponse:
+    try:
+        filePath = cameraTools.getRecordingFilePath(filename)
+    except ValueError as e:
+        raise HTTPException(400, str(e)) from e
+    except FileNotFoundError as e:
+        raise HTTPException(404, str(e)) from e
+    except Exception as e:
+        ml.elog(f"Failed to load recording file '{filename}': {e}")
+        raise HTTPException(500, "Failed to open recording file") from e
+
+    return FileResponse(path=filePath, media_type="video/mp4", filename=filePath.name)
 
 @app.get("/v1/kasa", summary="Get the list of discovered Kasa devices")
 async def getKasaDevices() -> list[KasaDeviceInfo]:

--- a/libqretprop/DeviceControllers/cameraTools.py
+++ b/libqretprop/DeviceControllers/cameraTools.py
@@ -111,7 +111,7 @@ async def connectAllCameras() -> None:
                     ml.slog(f"Configuring media server for camera {cam.hostname} ({camera_ip})")
                     await httpClient.post(f"http://{mediamtx_ip}:{mediamtx_port}/v3/config/paths/add/{cam.address}", json={
                         "source": f"rtsp://{cam_username}:{cam_password}@{cam.address}/stream1",
-                        "sourceOnDemand": True,
+                        "sourceOnDemand": False, # Always pull stream even if no viewers to ensure recording works
                         "recordPath": record_path,
                         "recordSegmentDuration": "2h",  # 2 hours per recording file segment to accommodate long sessions
                     }, timeout=aiohttp.ClientTimeout(10))

--- a/libqretprop/DeviceControllers/cameraTools.py
+++ b/libqretprop/DeviceControllers/cameraTools.py
@@ -29,6 +29,51 @@ def getRecordingsRoot() -> Path:
     return Path(recordingsDir).resolve()
 
 
+def _parseMediaMtxRecordFlag(data: dict) -> bool | None:
+    recordFlag = data.get("record")
+    if isinstance(recordFlag, bool):
+        return recordFlag
+
+    item = data.get("item")
+    if isinstance(item, dict):
+        recordFlag = item.get("record")
+        if isinstance(recordFlag, bool):
+            return recordFlag
+
+    return None
+
+
+async def _getMediaMtxPathRecordState(httpClient: aiohttp.ClientSession, pathName: str) -> bool | None:
+    mediamtxConfig = config.serverConfig["services"]["mediamtx"]
+    mediamtxIp = mediamtxConfig["ip"]
+    mediamtxPort = mediamtxConfig["api_port"]
+
+    try:
+        response = await httpClient.get(
+            f"http://{mediamtxIp}:{mediamtxPort}/v3/config/paths/get/{pathName}",
+            timeout=aiohttp.ClientTimeout(10),
+        )
+
+        if response.status == 404:
+            return None
+
+        if response.status != 200:
+            ml.elog(f"Failed to read MediaMTX path config for {pathName}: status {response.status}")
+            return None
+
+        data = await response.json()
+        if not isinstance(data, dict):
+            return None
+
+        return _parseMediaMtxRecordFlag(data)
+    except TimeoutError:
+        ml.elog(f"MediaMTX path config request timed out for {pathName}")
+    except Exception as e:
+        ml.elog(f"Failed reading MediaMTX path config for {pathName}: {e}")
+
+    return None
+
+
 def _extractIpFromFilename(filename: str) -> str | None:
     ipMatch = re.search(r"(\d{1,3}(?:\.\d{1,3}){3})", filename)
     if ipMatch is None:
@@ -117,6 +162,13 @@ async def connectAllCameras() -> None:
                     }, timeout=aiohttp.ClientTimeout(10))
                 except asyncio.TimeoutError:
                     ml.elog(f"Media server configuration timed out for {cam.hostname} ({camera_ip})")
+
+                recordState = await _getMediaMtxPathRecordState(httpClient, cam.address)
+                if recordState is None:
+                    cam.recording = False
+                    ml.elog(f"Could not determine recording state from MediaMTX path {cam.address}; defaulting to False")
+                else:
+                    cam.recording = recordState
 
 
 """Register a camera with its IP and port

--- a/libqretprop/DeviceControllers/cameraTools.py
+++ b/libqretprop/DeviceControllers/cameraTools.py
@@ -1,4 +1,7 @@
 import asyncio
+import re
+from pathlib import Path
+from typing import TypedDict
 
 import aiohttp
 
@@ -8,6 +11,78 @@ from libqretprop.Devices.Camera import Camera
 
 
 cameraRegistry: dict[str, Camera] = {}
+
+
+class RecordingFileData(TypedDict):
+    filename: str
+    camera_ip: str | None
+    camera_hostname: str | None
+    size_bytes: int
+    modified_unix_ms: int
+
+
+def getRecordingsRoot() -> Path:
+    mediamtxConfig = config.serverConfig["services"]["mediamtx"]
+    recordingsDir = mediamtxConfig.get("recordings_dir")
+    if not recordingsDir:
+        raise RuntimeError("MediaMTX recordings_dir is not configured")
+    return Path(recordingsDir).resolve()
+
+
+def _extractIpFromFilename(filename: str) -> str | None:
+    ipMatch = re.search(r"(\d{1,3}(?:\.\d{1,3}){3})", filename)
+    if ipMatch is None:
+        return None
+    return ipMatch.group(1)
+
+
+def listRecordingFiles(ip: str | None = None) -> list[RecordingFileData]:
+    recordingsRoot = getRecordingsRoot()
+    if not recordingsRoot.exists() or not recordingsRoot.is_dir():
+        message = f"Recording directory is unavailable: {recordingsRoot}"
+        raise RuntimeError(message)
+
+    cameraHostByIp: dict[str, str] = {cam.address: cam.hostname for cam in cameraRegistry.values()}
+    recordings: list[RecordingFileData] = []
+
+    for filePath in recordingsRoot.glob("*.mp4"):
+        if not filePath.is_file():
+            continue
+
+        cameraIp = _extractIpFromFilename(filePath.name)
+        if ip is not None and cameraIp != ip:
+            continue
+
+        stat = filePath.stat()
+        recordings.append(
+            {
+                "filename": filePath.name,
+                "camera_ip": cameraIp,
+                "camera_hostname": cameraHostByIp.get(cameraIp) if cameraIp is not None else None,
+                "size_bytes": stat.st_size,
+                "modified_unix_ms": int(stat.st_mtime * 1000),
+            },
+        )
+
+    recordings.sort(key=lambda rec: rec["modified_unix_ms"], reverse=True)
+    return recordings
+
+
+def getRecordingFilePath(filename: str) -> Path:
+    recordingsRoot = getRecordingsRoot()
+    safeFilename = Path(filename).name
+    if safeFilename != filename:
+        raise ValueError("Invalid recording filename")
+
+    filePath = (recordingsRoot / safeFilename).resolve()
+    if filePath.parent != recordingsRoot:
+        raise ValueError("Invalid recording path")
+
+    if not filePath.exists() or not filePath.is_file():
+        message = f"Recording not found: {safeFilename}"
+        raise FileNotFoundError(message)
+
+    return filePath
 """
 Connect to all camera defined in cameraConfig and register them
 """
@@ -30,11 +105,14 @@ async def connectAllCameras() -> None:
                 mediamtx_port = config.serverConfig["services"]["mediamtx"]["api_port"]
 
                 cam = cameraRegistry[camera_ip]
+                # MediaMTX resolves recordPath inside its own container filesystem.
+                record_path = str(Path("/recordings") / f"{cam.hostname}_%path_%Y%m%d_%H%M%S_%f")
                 try:
                     ml.slog(f"Configuring media server for camera {cam.hostname} ({camera_ip})")
                     await httpClient.post(f"http://{mediamtx_ip}:{mediamtx_port}/v3/config/paths/add/{cam.address}", json={
                         "source": f"rtsp://{cam_username}:{cam_password}@{cam.address}/stream1",
                         "sourceOnDemand": True,
+                        "recordPath": record_path,
                     }, timeout=aiohttp.ClientTimeout(10))
                 except asyncio.TimeoutError:
                     ml.elog(f"Media server configuration timed out for {cam.hostname} ({camera_ip})")
@@ -103,3 +181,88 @@ async def getStreamURL(ip: str) -> str:
     except Exception as e:
         ml.elog(f"Failed to get stream URL for camera at {ip}: {e}")
         raise
+
+async def startCameraRecording(ip: str) -> None:
+    if ip not in cameraRegistry:
+        ml.elog(f"Failed to start recording for camera at {ip}: Camera does not exist")
+        raise Exception(f"Camera {ip} does not exist")
+
+    # PATCH media server /v3/config/paths/patch/{ip} with {"record": true}
+    if config.serverConfig["services"]["mediamtx"] is not None:
+        mediamtx_ip = config.serverConfig["services"]["mediamtx"]["ip"]
+        mediamtx_port = config.serverConfig["services"]["mediamtx"]["api_port"]
+
+        async with aiohttp.ClientSession() as httpClient:
+            try:
+                ml.slog(f"Starting recording for camera at {ip} via media server API")
+                response = await httpClient.patch(f"http://{mediamtx_ip}:{mediamtx_port}/v3/config/paths/patch/{ip}", json={
+                    "record": True,
+                }, timeout=aiohttp.ClientTimeout(10))
+
+                if response.status != 200:
+                    raise Exception(f"Media server API returned status {response.status}")
+            except asyncio.TimeoutError:
+                ml.elog(f"Media server API request to start recording timed out for camera at {ip}")
+                raise Exception("Media server API request timed out")
+            except Exception as e:
+                ml.elog(f"Failed to start recording for camera at {ip}: {e}")
+                raise Exception(f"Failed to start recording for camera at {ip}: {e}")
+    else:
+        ml.elog(f"Failed to start recording for camera at {ip}: Media server is not configured")
+
+async def stopCameraRecording(ip: str) -> None:
+    if ip not in cameraRegistry:
+        ml.elog(f"Failed to stop recording for camera at {ip}: Camera does not exist")
+        raise Exception(f"Camera {ip} does not exist")
+
+    # PATCH media server /v3/config/paths/patch/{ip} with {"record": false}
+    if config.serverConfig["services"]["mediamtx"] is not None:
+        mediamtx_ip = config.serverConfig["services"]["mediamtx"]["ip"]
+        mediamtx_port = config.serverConfig["services"]["mediamtx"]["api_port"]
+
+        async with aiohttp.ClientSession() as httpClient:
+            try:
+                ml.slog(f"Stopping recording for camera at {ip} via media server API")
+                response = await httpClient.patch(f"http://{mediamtx_ip}:{mediamtx_port}/v3/config/paths/patch/{ip}", json={
+                    "record": False,
+                }, timeout=aiohttp.ClientTimeout(10))
+
+                if response.status != 200:
+                    raise Exception(f"Media server API returned status {response.status}")
+            except asyncio.TimeoutError:
+                ml.elog(f"Media server API request to stop recording timed out for camera at {ip}")
+                raise Exception("Media server API request timed out")
+            except Exception as e:
+                ml.elog(f"Failed to stop recording for camera at {ip}: {e}")
+                raise Exception(f"Failed to stop recording for camera at {ip}: {e}")
+    else:
+        ml.elog(f"Failed to stop recording for camera at {ip}: Media server is not configured")
+
+async def getCameraRecordings(ip: str) -> list[str]:
+    if ip not in cameraRegistry:
+        ml.elog(f"Failed to get recordings for camera at {ip}: Camera does not exist")
+        raise Exception(f"Camera {ip} does not exist")
+
+    if config.serverConfig["services"]["mediamtx"] is not None:
+        mediamtx_ip = config.serverConfig["services"]["mediamtx"]["ip"]
+        mediamtx_port = config.serverConfig["services"]["mediamtx"]["api_port"]
+
+        async with aiohttp.ClientSession() as httpClient:
+            try:
+                ml.slog(f"Getting recordings for camera at {ip} via media server API")
+                response = await httpClient.get(f"http://{mediamtx_ip}:{mediamtx_port}/v3/recordings/{ip}", timeout=aiohttp.ClientTimeout(10))
+
+                if response.status != 200:
+                    raise Exception(f"Media server API returned status {response.status}")
+
+                data = await response.json()
+                return data.get("recordings", [])
+            except asyncio.TimeoutError:
+                ml.elog(f"Media server API request to get recordings timed out for camera at {ip}")
+                raise Exception("Media server API request timed out")
+            except Exception as e:
+                ml.elog(f"Failed to get recordings for camera at {ip}: {e}")
+                raise Exception(f"Failed to get recordings for camera at {ip}: {e}")
+    else:
+        ml.elog(f"Failed to get recordings for camera at {ip}: Media server is not configured")
+        raise Exception("Media server is not configured")

--- a/libqretprop/DeviceControllers/cameraTools.py
+++ b/libqretprop/DeviceControllers/cameraTools.py
@@ -113,6 +113,7 @@ async def connectAllCameras() -> None:
                         "source": f"rtsp://{cam_username}:{cam_password}@{cam.address}/stream1",
                         "sourceOnDemand": True,
                         "recordPath": record_path,
+                        "recordSegmentDuration": "2h",  # 2 hours per recording file segment to accommodate long sessions
                     }, timeout=aiohttp.ClientTimeout(10))
                 except asyncio.TimeoutError:
                     ml.elog(f"Media server configuration timed out for {cam.hostname} ({camera_ip})")
@@ -201,6 +202,10 @@ async def startCameraRecording(ip: str) -> None:
 
                 if response.status != 200:
                     raise Exception(f"Media server API returned status {response.status}")
+
+                # Mark camera as recording in registry
+                cam = cameraRegistry[ip]
+                cam.recording = True
             except asyncio.TimeoutError:
                 ml.elog(f"Media server API request to start recording timed out for camera at {ip}")
                 raise Exception("Media server API request timed out")
@@ -229,6 +234,10 @@ async def stopCameraRecording(ip: str) -> None:
 
                 if response.status != 200:
                     raise Exception(f"Media server API returned status {response.status}")
+
+                # Mark camera as not recording in registry
+                cam = cameraRegistry[ip]
+                cam.recording = False
             except asyncio.TimeoutError:
                 ml.elog(f"Media server API request to stop recording timed out for camera at {ip}")
                 raise Exception("Media server API request timed out")

--- a/libqretprop/Devices/Camera.py
+++ b/libqretprop/Devices/Camera.py
@@ -23,6 +23,9 @@ class Camera:
         self.address = address
         self.port = port
 
+        # Whether the camera is currently recording via media server
+        self.recording = False
+
     async def connect(self) -> None:
         try:
             # Load wsdl files for ONVIF

--- a/libqretprop/configManager.py
+++ b/libqretprop/configManager.py
@@ -15,6 +15,7 @@ class MediaMTXConfig(TypedDict):
     ip: str
     api_port: int
     webrtc_port: int
+    recordings_dir: str
 
 class RedisConfig(TypedDict):
     ip: str
@@ -38,6 +39,7 @@ serverConfig: ServerConfig = {
             "ip": "",
             "api_port": 0,
             "webrtc_port": 0,
+            "recordings_dir": "./recordings/mediamtx",
         },
         "redis": {
             "ip": "",


### PR DESCRIPTION
Replace camera recording with native mediamtx recording feature, add recording is started/stopped and downloaded by the GUI. Continues recording on python service restart and gui disconnections.

GUI Update: https://github.com/Queens-Rocket-Engineering-Team/prop-new-control-gui/pull/9