### PR TITLE
Companion gui service

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
 COMPOSE_FILE=compose.dev.yml
 COMPOSE_PROJECT_NAME=prop-teststand
+COMPOSE_PROFILES=gui
+GUI_TAG=dev

--- a/.env
+++ b/.env
@@ -1,4 +1,2 @@
 COMPOSE_FILE=compose.dev.yml
 COMPOSE_PROJECT_NAME=prop-teststand
-COMPOSE_PROFILES=gui
-GUI_TAG=dev

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,8 +15,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0 # Need tag history for the GUI_TAG staleness check below
           persist-credentials: false
           submodules: recursive
+
+      - name: Check GUI_TAG pin isn't stale
+        run: |
+          previous_release="$(git describe --tags --abbrev=0 --exclude='*dev*' 2>/dev/null || true)"
+          if [ -z "$previous_release" ]; then
+            echo "No previous release tag found, skipping GUI_TAG staleness check."
+          else
+            previous_gui_tag="$(git show "${previous_release}:compose.prod.yml" | grep -oP '(?<=GUI_TAG:-)[^}]+' || true)"
+            current_gui_tag="$(grep -oP '(?<=GUI_TAG:-)[^}]+' compose.prod.yml || true)"
+            if [ -n "$previous_gui_tag" ] && [ "$previous_gui_tag" == "$current_gui_tag" ]; then
+              echo "::warning file=compose.prod.yml::GUI_TAG is still pinned to '${current_gui_tag}', same as release ${previous_release}. Confirm that's intentional before cutting the next release."
+            fi
+          fi
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ flowchart LR
 |---------|-------------|
 | **server** | Main application — device discovery (SSDP), TCP listener, FastAPI, CLI, in-process log stream |
 | **media** | [MediaMTX](https://github.com/bluenviron/mediamtx) RTSP/WebRTC relay for camera streams |
+| **gui** | View-only web GUI for engineers at the pad, served at `:8080` (static files only — issues no commands) |
 
 ## Setup
 
@@ -63,10 +64,13 @@ docker compose -f compose.dev.yml logs -f server
 ### Production (Docker)
 
 ```bash
-docker compose -f compose.prod.yml up -d
+GUI_TAG=v2.4.0 docker compose -f compose.prod.yml up -d
 ```
 
-Pulls pre-built images from `ghcr.io/queens-rocket-engineering-team/`.
+Pulls pre-built images from `ghcr.io/queens-rocket-engineering-team/`. `GUI_TAG`
+must be set to a published [prop-new-control-gui](https://github.com/queens-rocket-engineering-team/prop-new-control-gui)
+release tag — there's no `latest` fallback in prod, so pin it to whatever GUI
+version this server release was tested against.
 
 ### Local (No Docker)
 

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -66,5 +66,25 @@ services:
       - ./murmur.ini:/etc/mumble/murmur.ini
       - murmur-data:/data
 
+  # Optional view-only GUI for engineers at the pad, reachable at :8080.
+  # Off unless enabled:  COMPOSE_PROFILES=gui, or --profile gui
+  #
+  # Pulled rather than built: the GUI lives in prop-new-control-gui and is
+  # published by its own CI, so there is no local build context here. GUI_TAG
+  # defaults to `dev`, which that repo republishes on every push — pin it to a
+  # commit sha when you need certainty about what is running.
+  #
+  # No depends_on: this only serves static files, the browser reaches the API
+  # itself, so it has nothing to wait for and must not force `server` to start.
+  gui:
+    profiles: ["gui"]
+    image: ghcr.io/queens-rocket-engineering-team/prop-new-control-gui-web:${GUI_TAG:-dev}
+    network_mode: "host" # Matches the server service; nginx listens on 8080
+
+    environment:
+      # Unset means the GUI targets whichever host served the page, which is
+      # what you want when it runs alongside the server.
+      - PROP_SERVER_IP=${PROP_SERVER_IP:-}
+
 volumes:
   murmur-data:

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -66,8 +66,7 @@ services:
       - ./murmur.ini:/etc/mumble/murmur.ini
       - murmur-data:/data
 
-  # Optional view-only GUI for engineers at the pad, reachable at :8080.
-  # Off unless enabled:  COMPOSE_PROFILES=gui, or --profile gui
+  # View-only GUI for engineers at the pad, reachable at :8080.
   #
   # Pulled rather than built: the GUI lives in prop-new-control-gui and is
   # published by its own CI, so there is no local build context here. GUI_TAG
@@ -77,7 +76,6 @@ services:
   # No depends_on: this only serves static files, the browser reaches the API
   # itself, so it has nothing to wait for and must not force `server` to start.
   gui:
-    profiles: ["gui"]
     image: ghcr.io/queens-rocket-engineering-team/prop-new-control-gui-web:${GUI_TAG:-dev}
     network_mode: "host" # Matches the server service; nginx listens on 8080
 

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -64,9 +64,11 @@ services:
       # which is what you want when it runs alongside the server.
       - PROP_SERVER_IP=${PROP_SERVER_IP:-}
 
-    depends_on:
-      - server
-
+    # Deliberately no depends_on. This container only serves static files — the
+    # browser reaches the API itself — so it has nothing to wait for, and a
+    # dependency would force the `server` service to start even when the server
+    # is being run some other way (from source, or on another host). It would
+    # then contend for port 8000 with the one actually in use.
     restart: always
 
 volumes:

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -49,13 +49,12 @@ services:
   # View-only GUI for engineers at the pad, reachable at :8080. Serves static
   # files only — it issues no commands and the server is unaware of it.
   #
-  # GUI_TAG must be set explicitly (no default) to the published GUI version
-  # this release was tested against — e.g. GUI_TAG=v2.4.0. This is required
-  # rather than falling back to `latest` so that a server release keeps
-  # serving the same GUI build regardless of what the GUI repo publishes
-  # afterward.
+  # GUI_TAG is pinned here to the published GUI version tested against this
+  # release — bump it by hand as part of cutting each release. run-tests.yml
+  # prints a (non-blocking) warning if it hasn't changed since the previous
+  # release, as a nudge to double check it.
   gui:
-    image: ghcr.io/queens-rocket-engineering-team/prop-new-control-gui-web:${GUI_TAG:?Set GUI_TAG to a released GUI version, e.g. GUI_TAG=v2.4.0}
+    image: ghcr.io/queens-rocket-engineering-team/prop-new-control-gui-web:${GUI_TAG:-v1.0.0}
     network_mode: "host" # Matches the server service; nginx listens on 8080
 
     environment:

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -46,17 +46,16 @@ services:
 
     restart: always
 
-  # Optional view-only GUI for engineers at the pad, reachable at :8080.
-  # Serves static files only — it issues no commands and the server is unaware
-  # of it. Off unless explicitly enabled:
+  # View-only GUI for engineers at the pad, reachable at :8080. Serves static
+  # files only — it issues no commands and the server is unaware of it.
   #
-  #   COMPOSE_PROFILES=gui in .env, or `docker compose --profile gui up -d`
-  #
-  # GUI_TAG pins which published GUI version is served; leaving it at latest
-  # means a redeploy can change what pad tablets load.
+  # GUI_TAG must be set explicitly (no default) to the published GUI version
+  # this release was tested against — e.g. GUI_TAG=v2.4.0. This is required
+  # rather than falling back to `latest` so that a server release keeps
+  # serving the same GUI build regardless of what the GUI repo publishes
+  # afterward.
   gui:
-    profiles: ["gui"]
-    image: ghcr.io/queens-rocket-engineering-team/prop-new-control-gui-web:${GUI_TAG:-latest}
+    image: ghcr.io/queens-rocket-engineering-team/prop-new-control-gui-web:${GUI_TAG:?Set GUI_TAG to a released GUI version, e.g. GUI_TAG=v2.4.0}
     network_mode: "host" # Matches the server service; nginx listens on 8080
 
     environment:

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -46,5 +46,28 @@ services:
 
     restart: always
 
+  # Optional view-only GUI for engineers at the pad, reachable at :8080.
+  # Serves static files only — it issues no commands and the server is unaware
+  # of it. Off unless explicitly enabled:
+  #
+  #   COMPOSE_PROFILES=gui in .env, or `docker compose --profile gui up -d`
+  #
+  # GUI_TAG pins which published GUI version is served; leaving it at latest
+  # means a redeploy can change what pad tablets load.
+  gui:
+    profiles: ["gui"]
+    image: ghcr.io/queens-rocket-engineering-team/prop-new-control-gui-web:${GUI_TAG:-latest}
+    network_mode: "host" # Matches the server service; nginx listens on 8080
+
+    environment:
+      # Optional. Unset means the GUI targets whichever host served the page,
+      # which is what you want when it runs alongside the server.
+      - PROP_SERVER_IP=${PROP_SERVER_IP:-}
+
+    depends_on:
+      - server
+
+    restart: always
+
 volumes:
   murmur-data:


### PR DESCRIPTION
Adding a server-hosted instance of the gui so that view-only clients can connect to give a sensor dashboard for people at the panel and rocket.